### PR TITLE
Option to either remove user once or completely from the question queue.

### DIFF
--- a/ekan0ra/bot.py
+++ b/ekan0ra/bot.py
@@ -381,7 +381,7 @@ class LogBot(irc.IRCClient):
                         if self.qs_queue.has_next():
                             msg = '%s\n%s: You are next. Get ready with ' \
                                 'your question.' % (
-                                    msg, self.qs_queue.peek_next())
+                                    msg, self.qs_queue.peek())
                         self.say(self.channel, msg)
                         if self.config.SHOW_QUEUE_STATUS_ENABLED:
                             self.show_queue_status(channel)

--- a/ekan0ra/queue.py
+++ b/ekan0ra/queue.py
@@ -25,12 +25,15 @@ class Queue(list):
         """Add nick to queue."""
         self.append(nick)
 
-    def dequeue(self, nick):
+    def dequeue(self, nick, all=False):
         """
-        Remove every occurrence of user from a queue.
+        Remove every occurrence of `nick` from queue.
         """
         result=self.count(nick)>0
-        self=filter(lambda x: x!=nick,self)
+        if all and result:
+            self = filter(lambda x: x != nick, self)
+        elif result:
+            self.remove(nick)
         return result
 
     def has_next(self):

--- a/ekan0ra/queue.py
+++ b/ekan0ra/queue.py
@@ -40,7 +40,7 @@ class Queue(list):
         """Check if queue has at least one item."""
         return len(self) > 0
 
-    def peek_next(self):
+    def peek(self):
         """
         Get a look at the next item to be popped from the queue,
         but don't remove it from queue.


### PR DESCRIPTION
If a user no longer wants to ask a question and they have previously typed `!` more than once (meaning they have joined the queue more than once). This PR will make it so that when they type: `!!` or `!-`, then they should be removed completely from the queue, not just once.